### PR TITLE
Dataframes with required columns, using the exa.numerical system (_co…

### DIFF
--- a/exatomic/core/atom.py
+++ b/exatomic/core/atom.py
@@ -180,9 +180,9 @@ class UnitAtom(SparseDataFrame):
     _index = 'atom'
     _columns = ['x', 'y', 'z']
 
-    @property
-    def _constructor(self):
-        return UnitAtom
+    #@property
+    #def _constructor(self):
+    #    return UnitAtom
 
     @classmethod
     def from_universe(cls, universe):
@@ -215,9 +215,9 @@ class ProjectedAtom(SparseDataFrame):
     _index = 'two'
     _columns = ['x', 'y', 'z']
 
-    @property
-    def _constructor(self):
-        return ProjectedAtom
+    #@property
+    #def _constructor(self):
+    #    return ProjectedAtom
 
 
 class VisualAtom(SparseDataFrame):
@@ -243,9 +243,9 @@ class VisualAtom(SparseDataFrame):
             return cls(atom)
         raise PeriodicUniverseError()
 
-    @property
-    def _constructor(self):
-        return VisualAtom
+    #@property
+    #def _constructor(self):
+    #    return VisualAtom
 
 
 class Frequency(DataFrame):
@@ -272,9 +272,9 @@ class Frequency(DataFrame):
     | label             | int      | atomic identifier                         |
     +-------------------+----------+-------------------------------------------+
     """
-    @property
-    def _constructor(self):
-        return Frequency
+    #@property
+    #def _constructor(self):
+    #    return Frequency
 
     def displacement(self, freqdx):
         return self[self['freqdx'] == freqdx][['dx', 'dy', 'dz', 'symbol']]

--- a/exatomic/core/basis.py
+++ b/exatomic/core/basis.py
@@ -73,9 +73,9 @@ class BasisSet(DataFrame):
     _index = 'function'
     _categories = {'L': np.int64, 'set': np.int64, 'frame': np.int64, 'norm': str}
 
-    @property
-    def _constructor(self):
-        return BasisSet
+    #@property
+    #def _constructor(self):
+    #    return BasisSet
 
     @property
     def lmax(self):
@@ -180,9 +180,9 @@ class BasisSetOrder(DataFrame):
     _cardinal = ('frame', np.int64)
     _categories = {'L': np.int64}
 
-    @property
-    def _constructor(self):
-        return BasisSetOrder
+    #@property
+    #def _constructor(self):
+    #    return BasisSetOrder
 
 
 class Overlap(DataFrame):
@@ -210,9 +210,9 @@ class Overlap(DataFrame):
     _columns = ['chi0', 'chi1', 'coef', 'frame']
     _index = 'index'
 
-    @property
-    def _constructor(self):
-        return Overlap
+    #@property
+    #def _constructor(self):
+    #    return Overlap
 
     def square(self, frame=0, column='coef'):
         """Return a 'square' matrix DataFrame of the Overlap."""

--- a/exatomic/core/field.py
+++ b/exatomic/core/field.py
@@ -17,9 +17,9 @@ from exa import DataFrame, Field, Series
 class AField(DataFrame):
     _columns = ['nx', 'ny', 'nz', 'ox', 'oy', 'oz', 'dxi', 'dxj', 'dxk',
                 'dyi', 'dyj', 'dyk', 'dzi', 'dzj', 'dzk', 'frame']
-    @property
-    def _constructor(self):
-        return AField
+    #@property
+    #def _constructor(self):
+    #    return AField
 
     def copy(self, *args, **kwargs):
         """Make a copy of this object."""
@@ -58,9 +58,9 @@ class AtomicField(Field):
     _columns = ['nx', 'ny', 'nz', 'ox', 'oy', 'oz', 'dxi', 'dxj', 'dxk',
                 'dyi', 'dyj', 'dyk', 'dzi', 'dzj', 'dzk', 'frame']
 
-    @property
-    def _constructor(self):
-        return AtomicField
+    #@property
+    #def _constructor(self):
+    #    return AtomicField
 
     @property
     def nfields(self):

--- a/exatomic/core/matrices.py
+++ b/exatomic/core/matrices.py
@@ -74,9 +74,9 @@ class _Matrix(DataFrame):
     _index = 'index'
     _categories = {'frame': np.int64}
 
-    @property
-    def _constructor(self):
-        return _Matrix
+    #@property
+    #def _constructor(self):
+    #    return _Matrix
 
     @property
     def indices(self):
@@ -95,9 +95,9 @@ class _Matrix(DataFrame):
 
 class _Symmetric(_Matrix):
     """Base class for symmetric matrices."""
-    @property
-    def _constructor(self):
-        return _Symmetric
+    #@property
+    #def _constructor(self):
+    #    return _Symmetric
 
     def square(self, column=None):
         """Return a square DataFrame of the matrix."""
@@ -126,9 +126,9 @@ class _Symmetric(_Matrix):
 
 class _Square(_Matrix):
     """Base class for square matrices."""
-    @property
-    def _constructor(self):
-        return _Square
+    #@property
+    #def _constructor(self):
+    #    return _Square
 
     def square(self, column=None):
         """Return a square DataFrame of the square matrix."""
@@ -179,9 +179,9 @@ class Triangle(_Symmetric):
     """
     _columns = ['chi0', 'chi1']
 
-    @property
-    def _constructor(self):
-        return Triangle
+    #@property
+    #def _constructor(self):
+    #    return Triangle
 
     def merge(self, other, column=None):
         """

--- a/exatomic/core/molecule.py
+++ b/exatomic/core/molecule.py
@@ -22,9 +22,9 @@ class Molecule(DataFrame):
     _index = 'molecule'
     _categories = {'frame': np.int64, 'formula': str, 'classification': object}
 
-    @property
-    def _constructor(self):
-        return Molecule
+    #@property
+    #def _constructor(self):
+    #    return Molecule
 
     def classify(self, *classifiers):
         """

--- a/exatomic/core/orbital.py
+++ b/exatomic/core/orbital.py
@@ -139,9 +139,9 @@ class Orbital(_Convolve):
     _cardinal = ('frame', np.int64)
     _categories = {'spin': np.int64, 'frame': np.int64, 'group': np.int64}
 
-    @property
-    def _constructor(self):
-        return Orbital
+    #@property
+    #def _constructor(self):
+    #    return Orbital
 
     def get_orbital(self, orb=-1, spin=0, index=None, group=None, frame=None):
         """
@@ -243,9 +243,9 @@ class Excitation(_Convolve):
     _cardinal = ('frame', np.int64)
     _categories = {'frame': np.int64, 'group': np.int64}
 
-    @property
-    def _constructor(self):
-        return Excitation
+    #@property
+    #def _constructor(self):
+    #    return Excitation
 
     @classmethod
     def from_universe(cls, uni, initial=None, final=None, spin=0):
@@ -306,9 +306,9 @@ class MOMatrix(DataFrame):
     _cardinal = ('frame', np.int64)
     _index = 'index'
 
-    @property
-    def _constructor(self):
-        return MOMatrix
+    #@property
+    #def _constructor(self):
+    #    return MOMatrix
 
     def contributions(self, orbital, mocoefs='coef', tol=0.01, frame=0):
         """
@@ -353,9 +353,9 @@ class DensityMatrix(DataFrame):
     _cardinal = ('frame', np.int64)
     _index = 'index'
 
-    @property
-    def _constructor(self):
-        return DensityMatrix
+    #@property
+    #def _constructor(self):
+    #    return DensityMatrix
 
     def square(self, frame=0):
         """Returns a square dataframe of the density matrix."""

--- a/exatomic/core/tensor.py
+++ b/exatomic/core/tensor.py
@@ -43,9 +43,9 @@ class Tensor(DataFrame):
                 'frame','atom','label']
     _categories = {'frame': np.int64, 'label': str}
 
-    @property
-    def _constructor(self):
-        return Tensor
+    #@property
+    #def _constructor(self):
+    #    return Tensor
 
     @classmethod
     def from_file(cls, filename):


### PR DESCRIPTION
…lumns, _indexes - class level attributes), are not fully compatible with slicing when using _constructor property. I've left the ``_constructors`` where appropriate and fully compatible.