### PR TITLE
Fixes for diffusion and neighbors

### DIFF
--- a/exatomic/algorithms/diffusion.py
+++ b/exatomic/algorithms/diffusion.py
@@ -10,7 +10,8 @@ from exa.util.units import Length, Time
 from exatomic.algorithms.displacement import absolute_squared_displacement
 
 
-def einstein_relation(universe, length='cm', time='s'):
+def einstein_relation(universe, input_time='ps', input_length='au',
+                      length='cm', time='s'):
     """
     Compute the (time dependent) diffusion coefficient using Einstein's relation.
 
@@ -22,18 +23,20 @@ def einstein_relation(universe, length='cm', time='s'):
         D = \\lim_{t\\to\\infty} D\\left(t\\right)
 
     Args:
-        universe (:class:`~exatomic.Universe`): The universe object
-        msd (:class:`~exa.DataFrame`): Mean squared displacement dataframe
+        universe (:class:`~exatomic.core.universe.Universe`): The universe object
+        input_time (str): String unit of 'time' column in frame table
+        input_length (str): String unit of xyz coordinates
+        length (str): String unit name of output length unit
+        time (str): Sting unit name of output time unit
 
     Returns:
-        D (:class:`~exa.DataFrame`): Diffussion coefficient as a function of time
+        d (:class:`~exa.core.numerical.DataFrame`): Diffussion coefficient as a function of time
 
     Note:
         The asymptotic value of the returned variable is the diffusion coefficient.
         The default units of the diffusion coefficient are :math:`\\frac{cm^{2}}{s}`.
     """
     msd = absolute_squared_displacement(universe).mean(axis=1)
-    t = universe.frame['time'].values
-    msd *= Length['au', length]**2
-    t /= Time['au', time]
-    return msd / (6 * t)
+    t = universe.frame['time'] / Time[input_time, time]
+    msd *= Length[input_length, length]**2
+    return msd/(6*t)

--- a/exatomic/algorithms/displacement.py
+++ b/exatomic/algorithms/displacement.py
@@ -31,16 +31,14 @@ def absolute_squared_displacement(universe, ref_frame=None):
     else:
         frames = universe.frame.index.values
         ref_frame = np.where(frames == ref_frame)
-    coldata = universe.atom.ix[universe.atom['frame'] == ref_frame, ['label', 'symbol']]
-    coldata = (coldata['label'].astype(str) + '_' + coldata['symbol'].astype(str)).values
-    universe.atom['label'] = universe.atom.get_atom_labels()
+    if 'label' not in universe.atom.columns:
+        universe.atom['label'] = universe.atom.get_atom_labels()
     groups = universe.atom.groupby('label')
     msd = np.empty((groups.ngroups, ), dtype='O')
     for i, (_, group) in enumerate(groups):
         xyz = group[['x', 'y', 'z']].values
         msd[i] = ((xyz - xyz[0])**2).sum(axis=1)
-    del universe.atom['label']
     df = pd.DataFrame.from_records(msd).T
     df.index = universe.frame.index.copy()
-    df.columns = coldata
+    df.columns = universe.atom['label'].unique()
     return df

--- a/exatomic/algorithms/neighbors.py
+++ b/exatomic/algorithms/neighbors.py
@@ -108,7 +108,7 @@ def periodic_nearest_neighbors_by_atom(uni, source, a, sizes, **kwargs):
 
     Args:
         uni (:class:`~exatomic.core.universe.Universe`): Universe
-        source (int, str): Integer label or string symbol of source atom
+        source (int, str, list): Integer label or string symbol of source atom
         a (float): Cubic unit cell dimension
         sizes (list): List of slices to create
         kwargs: Additional keyword arguments to be passed to atom two body computation (such as covalent radii)
@@ -137,13 +137,16 @@ def periodic_nearest_neighbors_by_atom(uni, source, a, sizes, **kwargs):
             uu = _create_super_universe(Universe(atom=atom.copy()), a)
             uu.compute_atom_two(**kwargs)
             uu.compute_molecule()
-            if isinstance(source, (int, np.int32, np.int64)):
+            if isinstance(source, (str, int, np.int32, np.int64)):
                 source_atom_idxs = uu.atom[(uu.atom['label'] == source) &
+                                           (uu.atom['prj'] == 13)].index.values
+            elif isinstance(source, (list, tuple)):
+                source_atom_idxs = uu.atom[uu.atom['label'].isin(source) &
                                            (uu.atom['prj'] == 13)].index.values
             else:
                 source_atom_idxs = uu.atom[(uu.atom['symbol'] == source) &
                                            (uu.atom['prj'] == 13)].index.values
-            source_molecule_idxs = uu.atom.loc[source_atom_idxs, 'molecule'].unique()
+            source_molecule_idxs = uu.atom.loc[source_atom_idxs, 'molecule'].unique().astype(int)
             uu.atom_two['frame'] = uu.atom_two['atom0'].map(uu.atom['frame'])
             nearest_atoms = uu.atom_two[(uu.atom_two['atom0'].isin(source_atom_idxs)) |
                                         (uu.atom_two['atom1'].isin(source_atom_idxs))].sort_values("dr")[['frame', 'atom0', 'atom1']]


### PR DESCRIPTION
The mean square displacement function could modify the universe's frame table in place incorrectly. This occurred randomly due to view/copy of dataframes. Added support in out of core neighbors for multiple source atom labels.