### PR TITLE
Adding patch for type specification when adding molecular orbitals

### DIFF
--- a/exatomic/core/basis.py
+++ b/exatomic/core/basis.py
@@ -141,7 +141,7 @@ class BasisSet(DataFrame):
         else:
             mapper = lambda x: cart_lml_count[x]
         n = self.functions_by_shell()
-        return n * n.index.get_level_values('L').map(mapper)
+        return n * n.index.get_level_values('L').map(mapper).astype(np.int64)
 
     def primitives(self, spherical):
         """Return a series of n primitives per (set, L).
@@ -151,7 +151,7 @@ class BasisSet(DataFrame):
         else:
             mapper = lambda x: cart_lml_count[x]
         n = self.primitives_by_shell()
-        return n * n.index.get_level_values('L').map(mapper)
+        return n * n.index.get_level_values('L').map(mapper).astype(np.int64)
 
     #def __init__(self, *args, **kwargs):
         #spherical = kwargs.pop("spherical", True)


### PR DESCRIPTION
Adding a quick fix for the molecular orbital functions. Addresses and closes #144.
This should also fix some of the issues with the tests. 