### PR TITLE
Atom table transformations

### DIFF
--- a/exatomic/core/atom.py
+++ b/exatomic/core/atom.py
@@ -84,7 +84,7 @@ class Atom(DataFrame):
             else: frame[r] = frame[r] + np.abs(center[r])
         return frame
 
-    def rotate(self, theta, axis=[0,0,1], frame=None, degrees=True):
+    def rotate(self, theta, axis=None, frame=None, degrees=True):
         """
         Return a copy of a single frame of the atom table rotated
         around the specified rotation axis by the specified angle.
@@ -101,10 +101,11 @@ class Atom(DataFrame):
         Returns:
             frame (:class:`exatomic.Universe.atom`): Atom frame
         """
+        if axis is None: axis = [0, 0, 1]
         if frame is None: frame = self.last_frame.copy()
         else: frame = self[self.frame == frame].copy()
         # as we have the rotation axis and the angle we will rotate over
-        # we implement the Rodrigues formula
+        # we implement the Rodrigues' rotation formula
         # v_rot = v*np.cos(theta) + (np.cross(k,v))*np.sin(theta) + k*(np.dot(k,v))*(1-np.cos(theta))
 
         # convert units if not degrees
@@ -139,7 +140,7 @@ class Atom(DataFrame):
             Vector can be used instead of dx, dy, dz as it will be decomposed
             into those components. If vector and any of the others are
             specified the values in vector will be used.
-        
+
         Args:
             dx (float): Displacement distance in x
             dy (float): Displacement distance in y

--- a/exatomic/core/atom.py
+++ b/exatomic/core/atom.py
@@ -129,7 +129,41 @@ class Atom(DataFrame):
         rotated = a + b + c
         frame[['x', 'y', 'z']] = rotated
         return frame
+
+    def translate(self, dx=0, dy=0, dz=0, vector=None, frame=None, units='au'):
+        """
+        Return a copy of a single frame of the atom table translated by
+        some specified distance.
+
+        Note:
+            Vector can be used instead of dx, dy, dz as it will be decomposed
+            into those components. If vector and any of the others are
+            specified the values in vector will be used.
         
+        Args:
+            dx (float): Displacement distance in x
+            dy (float): Displacement distance in y
+            dz (float): Displacement distance in z
+            vector (list): Displacement vector
+            units (str): Units that are used for the displacement
+
+        Returns:
+            frame (:class:`exatomic.Universe.atom`): Atom frame
+        """
+        if frame is None: frame = self.last_frame.copy()
+        else: frame = self[self.frame == frame].copy()
+        # check if vector is specified
+        if vector is not None:
+            # convert vector units to au
+            vector = [i * Length[units, 'au'] for i in vector]
+            dx = vector[0]
+            dy = vector[1]
+            dz = vector[2]
+        # add the values to each respective coordinate
+        frame['x'] += dx
+        frame['y'] += dy
+        frame['z'] += dz
+        return frame
 
     def to_xyz(self, tag='symbol', header=False, comments='', columns=None,
                frame=None, units='Angstrom'):

--- a/exatomic/core/atom.py
+++ b/exatomic/core/atom.py
@@ -84,6 +84,15 @@ class Atom(DataFrame):
             else: frame[r] = frame[r] + np.abs(center[r])
         return frame
 
+    def rotate(self, theta, axis=[0,0,1], frame=None, degrees=True):
+        pass
+        if frame is None: frame = self.last_frame.copy()
+        else: frame = self[self.frame == frame].copy()
+        # as we have the rotation axis and the angle we will rotate over
+        # we implement the Rodrigues formula
+        # v_rot = v*np.cos(theta) + (np.cross(k,v))*np.sin(theta) + k*(np.dot(k,v))*(1-np.cos(theta))
+        if degrees: theta = theta*np.pi/180.
+        
 
     def to_xyz(self, tag='symbol', header=False, comments='', columns=None,
                frame=None, units='Angstrom'):


### PR DESCRIPTION
This PR closes #86
Additions:
 - Added functionality to rotate and translate a frame of the atom table

Example Code:
```
from exatomic import gaussian
from exatomic.base import resource

uni = gaussian.Output(resource('g09-ch3nh2-631g.out')).to_universe()
# just to see the current atom table
uni.atom
# rotate atom table 90 degrees about z axis
rotation = uni.atom.rotate(theta=90, axis=[0,0,1], degrees=True)
# translate atom table 5 angstroms in x
trans_1 = uni.atom.translate(dx=5, units='Angstrom')
# or
trans_2 = uni.atom.translate(vector=[5,0,0], units='Angstroms')
```