### PR TITLE
Add logging functionality

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ install:
     - conda create -y -n test python=$PYTHONVER
     - source activate test
     - conda update -q -y --all
-    - conda install -q -y -c conda-forge six numpy pandas pytables numba
+    - conda install -q -y -c conda-forge six numpy pandas pytables numba pyyaml
     - conda install -q -y -c conda-forge sphinx sphinx_rtd_theme ply sympy
     - conda install -q -y -c conda-forge pandoc pypandoc nbsphinx ipython seaborn
     - conda install -q -y -c conda-forge coveralls coverage pytest pytest-cov

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 recursive-include exatomic/static *
+recursive-include exatomic/conf *
 include requirements.txt

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -57,7 +57,7 @@ install:
   - cmd: activate test
   - cmd: conda update -q -y --all
   - cmd: conda install -q -y -c conda-forge numpy scipy seaborn networkx pandas
-  - cmd: conda install -q -y -c conda-forge pytest pytables six numba sympy
+  - cmd: conda install -q -y -c conda-forge pytest pytables six numba sympy pyyaml
   - cmd: conda install -q -y -c conda-forge psutil numexpr nodejs ipywidgets
 # - cmd: conda install -q -y -c exaanalytics exa
 # - cmd: pip install exa

--- a/exatomic/__init__.py
+++ b/exatomic/__init__.py
@@ -48,6 +48,22 @@ def _jupyter_nbextension_paths():
         'require': "exatomic/extension"
     }]
 
+import os
+import tempfile
+import logging.config
+import yaml
+
+with open(os.path.join(os.path.dirname(__file__),
+          'conf', 'logging.yml'), 'r') as f:
+    _log = yaml.safe_load(f.read())
+_log['handlers']['file']['filename'] = os.path.join(tempfile.gettempdir(),
+                                                    'exa.log')
+logging.config.dictConfig(_log)
+
+def func_log(func):
+    name = '.'.join([func.__module__,
+                     func.__name__])
+    return logging.getLogger(name)
 
 from ._version import __version__
 from . import core

--- a/exatomic/algorithms/orbital.py
+++ b/exatomic/algorithms/orbital.py
@@ -127,7 +127,7 @@ def add_orb_ang_mom(uni, field_params=None, rcoefs=None, icoefs=None,
     angular momentum.  Requires C matrices from SODIZLDENS.X.X.R,I
     files from Molcas.
 
-    Args
+    Args:
         uni (:class:`~exatomic.container.Universe`): a universe
         field_params (dict): See :func:`~exatomic.algorithms.orbital_util.make_fps`
         rcoefs (str): column in uni.current_momatrix (default 'lreal')

--- a/exatomic/conf/logging.yml
+++ b/exatomic/conf/logging.yml
@@ -1,0 +1,25 @@
+version: 1
+disable_existing_loggers: True
+formatters:
+    verbose:
+        format: '[%(levelname)s %(asctime)s] %(name)s %(message)s'
+    simple:
+        format: '%(levelname)s %(message)s'
+handlers:
+    console:
+        level: DEBUG
+        class: logging.StreamHandler
+        formatter: 'verbose'
+    file:
+        level: INFO
+        class: logging.handlers.RotatingFileHandler
+        formatter: 'verbose'
+        filename: '/tmp/exatomic.log'
+        mode: 'a'
+        maxBytes: 10485760
+        backupCount: 5
+loggers:
+    exatomic:
+        handlers: ['console', 'file']
+        level: DEBUG
+        propagate: False

--- a/meta.yaml
+++ b/meta.yaml
@@ -24,6 +24,7 @@ requirements:
     - exa
     - sympy
     - symengine
+    - pyyaml
 
 test:
   imports:

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ seaborn
 ipywidgets
 sympy
 numexpr
+pyyaml


### PR DESCRIPTION
Largely consistent with additions made in https://github.com/exa-analytics/exa/pull/162 , this merge request intends to introduce logging functionality. The default logging configurations are copied in both repositories, but this allows to keep each independently configurable by changing handlers and levels on loggers inheriting from `logging.getLogger(f'exa.{foo}')` and `logging.getLogger(f'exatomic.{bar}')` 

I also added a `func_log` method to the root namespace to offer similar logging behavior as with the established instance logging for when the functional approach is more appropriate. `algorithms.orbital` received a conversion to convert print statements to logging statements using this approach.

This is only the setup and a minimal working example. Much more work should be done for rich logging features but this lays the ground work.