### PR TITLE
Updates js deps and removes vulnerability warning

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -22,15 +22,20 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "devDependencies": {
-    "json-loader": "^0.5.4",
-    "webpack": "^1.12.14"
+    "@babel/core": "^7.4.3",
+    "@babel/preset-env": "^7.4.3",
+    "babel-loader": "^8.0.5",
+    "babel-plugin-syntax-dynamic-import": "^6.18.0",
+    "uglifyjs-webpack-plugin": "^2.1.2",
+    "webpack": "^4.30.0",
+    "webpack-cli": "^3.3.0"
   },
   "dependencies": {
-    "@jupyter-widgets/base": "^1.0.0",
-    "@jupyter-widgets/controls": "^1.0.0",
-    "underscore": "^1.8.3",
-    "three": "^0.82.0",
-    "three-trackballcontrols": "^0.0.5"
+    "@jupyter-widgets/base": "^1.2.4",
+    "@jupyter-widgets/controls": "^1.4.4",
+    "three": "^0.100.0",
+    "three-trackballcontrols": "^0.0.7",
+    "underscore": "^1.9.1"
   },
   "jupyterlab": {
     "extension": "src/jupyterlab-plugin"


### PR DESCRIPTION
I was installing a development JS version from master and npm complained about a vulnerability in a dependency we had. It seemed like a good time to version bump our JS deps anyway. I believe that this won't build properly until we push a new npm release because of the dependency mismatch but I want to open the pull request now anyway. I am also not sure if the updated JS deps make for working widgets on Windows in Edge so I would like to test that out before merging this in.