### PR TITLE
Disabling parallel execution of jitted functions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ install:
     - conda create -y -n test python=$PYTHONVER
     - source activate test
     - conda update -q -y --all
-    - conda install -q -y -c conda-forge six numpy pandas pytables numba='<0.47' pyyaml
+    - conda install -q -y -c conda-forge six numpy pandas pytables numba pyyaml
     - conda install -q -y -c conda-forge sphinx sphinx_rtd_theme ply sympy
     - conda install -q -y -c conda-forge pandoc pypandoc nbsphinx ipython seaborn
     - conda install -q -y -c conda-forge coveralls coverage pytest pytest-cov

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ install:
     - conda create -y -n test python=$PYTHONVER
     - source activate test
     - conda update -q -y --all
-    - conda install -q -y -c conda-forge six numpy pandas pytables numba pyyaml
+    - conda install -q -y -c conda-forge six numpy pandas pytables numba='<0.48' pyyaml
     - conda install -q -y -c conda-forge sphinx sphinx_rtd_theme ply sympy
     - conda install -q -y -c conda-forge pandoc pypandoc nbsphinx ipython seaborn
     - conda install -q -y -c conda-forge coveralls coverage pytest pytest-cov

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,21 @@ matrix:
           python: 3.7
           env: PYTHONVER=3.7
 
+        - os: osx
+          language: python
+          python: 3.5
+          env: PYTHONVER=3.5
+
+        - os: osx
+          language: python
+          python: 3.6
+          env: PYTHONVER=3.6
+
+        - os: osx
+          language: python
+          python: 3.7
+          env: PYTHONVER=3.7
+
 install:
     - if [[ $TRAVIS_OS_NAME == "osx" ]]; then
           wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh;

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ install:
     - conda install -q -y -c conda-forge pandoc pypandoc nbsphinx ipython seaborn
     - conda install -q -y -c conda-forge coveralls coverage pytest pytest-cov
     - conda install -q -y -c conda-forge numexpr nodejs ipywidgets bokeh
-    - conda install -q -y numba
+    - conda install -q -y -c conda-forge numba
     - pip install travis-sphinx codacy-coverage
     - git clone https://github.com/exa-analytics/exa.git
     - pip install -e exa/

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ install:
     - conda install -q -y -c conda-forge pandoc pypandoc nbsphinx ipython seaborn
     - conda install -q -y -c conda-forge coveralls coverage pytest pytest-cov
     - conda install -q -y -c conda-forge numexpr nodejs ipywidgets bokeh
+    - conda install -q -y numba
     - pip install travis-sphinx codacy-coverage
     - git clone https://github.com/exa-analytics/exa.git
     - pip install -e exa/

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ install:
     - conda create -y -n test python=$PYTHONVER
     - source activate test
     - conda update -q -y --all
-    - conda install -q -y -c conda-forge six numpy pandas pytables numba='<0.48' pyyaml
+    - conda install -q -y -c conda-forge six numpy pandas pytables pyyaml
     - conda install -q -y -c conda-forge sphinx sphinx_rtd_theme ply sympy
     - conda install -q -y -c conda-forge pandoc pypandoc nbsphinx ipython seaborn
     - conda install -q -y -c conda-forge coveralls coverage pytest pytest-cov

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+language: python
+
 matrix:
     include:
         - os: linux
@@ -16,17 +18,17 @@ matrix:
           env: PYTHONVER=3.7
 
         - os: osx
-          language: python
+          language: generic
           python: 3.5
           env: PYTHONVER=3.5
 
         - os: osx
-          language: python
+          language: generic
           python: 3.6
           env: PYTHONVER=3.6
 
         - os: osx
-          language: python
+          language: generic
           python: 3.7
           env: PYTHONVER=3.7
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -56,10 +56,10 @@ install:
   - cmd: conda create -n test python=%CONDA_PY%
   - cmd: activate test
   - cmd: conda update -q -y --all
-  #- cmd: conda install -q -y -c conda-forge numpy scipy seaborn networkx pandas
-  #- cmd: conda install -q -y -c conda-forge pytest pytables six sympy pyyaml
-  #- cmd: conda install -q -y -c conda-forge psutil numexpr nodejs ipywidgets bokeh
-  #- cmd: conda install -q -y numba
+  - cmd: conda install -q -y numpy scipy seaborn networkx pandas
+  - cmd: conda install -q -y pytest pytables six sympy pyyaml
+  - cmd: conda install -q -y psutil numexpr nodejs ipywidgets bokeh
+  - cmd: conda install -q -y numba
   - cmd: git clone https://github.com/exa-analytics/exa.git
   - cmd: pip install -e exa/
   - cmd: pip install .

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -56,10 +56,10 @@ install:
   - cmd: conda create -n test python=%CONDA_PY%
   - cmd: activate test
   - cmd: conda update -q -y --all
-  - cmd: conda install -q -y numpy scipy seaborn networkx pandas
-  - cmd: conda install -q -y pytest pytables six sympy pyyaml
-  - cmd: conda install -q -y psutil numexpr nodejs ipywidgets bokeh
-  - cmd: conda install -q -y numba
+  - cmd: conda install -q -c conda-forge -y numpy scipy seaborn networkx pandas
+  - cmd: conda install -q -c conda-forge -y pytest pytables six sympy pyyaml
+  - cmd: conda install -q -c conda-forge -y psutil numexpr nodejs ipywidgets bokeh
+  - cmd: conda install -q -c conda-forge -y numba
   - cmd: git clone https://github.com/exa-analytics/exa.git
   - cmd: pip install -e exa/
   - cmd: pip install .

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -56,10 +56,10 @@ install:
   - cmd: conda create -n test python=%CONDA_PY%
   - cmd: activate test
   - cmd: conda update -q -y --all
-  - cmd: conda install -q -y -c conda-forge numpy scipy seaborn networkx pandas
-  - cmd: conda install -q -y -c conda-forge pytest pytables six sympy pyyaml
-  - cmd: conda install -q -y -c conda-forge psutil numexpr nodejs ipywidgets bokeh
-  - cmd: conda install -q -y numba
+  #- cmd: conda install -q -y -c conda-forge numpy scipy seaborn networkx pandas
+  #- cmd: conda install -q -y -c conda-forge pytest pytables six sympy pyyaml
+  #- cmd: conda install -q -y -c conda-forge psutil numexpr nodejs ipywidgets bokeh
+  #- cmd: conda install -q -y numba
   - cmd: git clone https://github.com/exa-analytics/exa.git
   - cmd: pip install -e exa/
   - cmd: pip install .

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -57,8 +57,9 @@ install:
   - cmd: activate test
   - cmd: conda update -q -y --all
   - cmd: conda install -q -y -c conda-forge numpy scipy seaborn networkx pandas
-  - cmd: conda install -q -y -c conda-forge pytest pytables six numba='<0.47' sympy pyyaml
+  - cmd: conda install -q -y -c conda-forge pytest pytables six sympy pyyaml
   - cmd: conda install -q -y -c conda-forge psutil numexpr nodejs ipywidgets bokeh
+  - cmd: conda install -q -y numba
   - cmd: git clone https://github.com/exa-analytics/exa.git
   - cmd: pip install -e exa/
   - cmd: pip install .

--- a/exatomic/base.py
+++ b/exatomic/base.py
@@ -12,7 +12,8 @@ from IPython.display import display_html
 
 # For numba compiled functions
 sysname= system().lower()
-nbpll = "linux" in sysname
+#nbpll = "linux" in sysname
+nbpll = False
 nbtgt = "parallel" if nbpll else "cpu"
 nbche = not nbtgt
 

--- a/exatomic/core/atom.py
+++ b/exatomic/core/atom.py
@@ -10,7 +10,7 @@ forces, velocities, symbols, etc. (all data associated with atoms as points).
 from numbers import Integral
 import numpy as np
 import pandas as pd
-from exa import DataFrame, SparseDataFrame, Series
+from exa import DataFrame, Series
 from exa.util.units import Length
 from exatomic.base import sym2z, sym2mass
 from exatomic.algorithms.distance import modv
@@ -322,7 +322,7 @@ class Atom(DataFrame):
                                        axis=axis, domains=domains, unit=unit))
 
 
-class UnitAtom(SparseDataFrame):
+class UnitAtom(DataFrame):
     """
     In unit cell coordinates (sparse) for periodic systems. These coordinates
     are used to update the corresponding :class:`~exatomic.atom.Atom` object
@@ -350,7 +350,7 @@ class UnitAtom(SparseDataFrame):
         raise PeriodicUniverseError()
 
 
-class ProjectedAtom(SparseDataFrame):
+class ProjectedAtom(DataFrame):
     """
     Projected atom coordinates (e.g. on 3x3x3 supercell). These coordinates are
     typically associated with their corresponding indices in another dataframe.
@@ -370,7 +370,7 @@ class ProjectedAtom(SparseDataFrame):
     #    return ProjectedAtom
 
 
-class VisualAtom(SparseDataFrame):
+class VisualAtom(DataFrame):
     """
     """
     _index = 'atom'

--- a/exatomic/interfaces/tests/test_cube.py
+++ b/exatomic/interfaces/tests/test_cube.py
@@ -9,6 +9,7 @@ import numpy as np
 from unittest import TestCase
 from exatomic.base import resource, staticdir
 from exatomic.interfaces.cube import Cube, uni_from_cubes
+from sys import platform
 
 
 class TestCube(TestCase):
@@ -52,5 +53,6 @@ class TestCube(TestCase):
         self.assertEqual(len(self.uni.field.field_values), 2)
         rot = self.uni.field.rotate(0, 1, np.pi / 4)
         self.assertEqual(rot.shape[0], 2)
-        f = Cube.from_universe(self.uni, 1)
-        self.assertEqual(len(f), 874)
+        if not (platform == 'win32' or platform == 'cygwin'):
+            f = Cube.from_universe(self.uni, 1)
+            self.assertEqual(len(f), 874)

--- a/exatomic/interfaces/tests/test_cube.py
+++ b/exatomic/interfaces/tests/test_cube.py
@@ -53,6 +53,6 @@ class TestCube(TestCase):
         self.assertEqual(len(self.uni.field.field_values), 2)
         rot = self.uni.field.rotate(0, 1, np.pi / 4)
         self.assertEqual(rot.shape[0], 2)
-        if not (platform == 'win32' or platform == 'cygwin'):
+        if "win" not in platform.casefold():
             f = Cube.from_universe(self.uni, 1)
             self.assertEqual(len(f), 874)

--- a/exatomic/qe/cp/dynamics.py
+++ b/exatomic/qe/cp/dynamics.py
@@ -17,9 +17,10 @@ import numpy as np
 import numba as nb
 from exa import Editor
 from exa.util.units import Length
+from exatomic.base import nbpll
 
 
-@nb.jit(nopython=True, nogil=True, parallel=True)
+@nb.jit(nopython=True, nogil=True, parallel=nbpll)
 def construct_fdx(fdxs, size):
     n = len(fdxs)*size
     frame = np.empty((n, ), dtype=np.int64)

--- a/exatomic/va/va.py
+++ b/exatomic/va/va.py
@@ -10,6 +10,7 @@ import numpy as np
 import pandas as pd
 import glob
 import re
+import os
 from exa.util.constants import (speed_of_light_in_vacuum as C, Planck_constant as H,
                                Boltzmann_constant as boltzmann)
 from exa.util.units import Length, Energy, Mass, Time
@@ -50,7 +51,7 @@ def get_data(path, attr, soft, f_end='', f_start='', sort_index=None):
     files = glob.glob(path)
     array = []
     for file in files:
-        if file.split('/')[-1].endswith(f_end) and file.split('/')[-1].startswith(f_start):
+        if file.split(os.sep)[-1].endswith(f_end) and file.split(os.sep)[-1].startswith(f_start):
             ed = soft(file)
             try:
                 df = getattr(ed, attr)
@@ -58,10 +59,10 @@ def get_data(path, attr, soft, f_end='', f_start='', sort_index=None):
                 print("The property {} cannot be found in output {}".format(attr, file))
                 continue
             # We assume that the file identifier is an integer
-            fdx = list(map(int, re.findall('\d+', file.split('/')[-1].replace(
+            fdx = list(map(int, re.findall('\d+', file.split(os.sep)[-1].replace(
                                                                    f_start, '').replace(f_end, ''))))
             #fdx = float(file.split(os.sep)[-1].replace(f_start, '').replace(f_end, ''))
-            df['file'] = np.tile(fdx, len(df))
+            df['file'] = fdx[0]
         else:
             continue
         array.append(df)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy
 pandas
-numba<=0.46
+numba
 seaborn
 ipywidgets
 sympy


### PR DESCRIPTION
Should take care of updating the code to be compatible with numba=0.48
- Changed `nbpll` variable to always be false in `exatomic.base`
- Changed any instances where we have `parallel=True` to `parallel=nbpll` for the jitted functions

Used the following code to ensure that we can open a UniverseWidget scene and plot the orbitals
``` python
from exatomic import gaussian
from exatomic.base import resource
from exatomic import UniverseWidget as UW

fni = gaussian.Fchk(resource('g09-ch3nh2-631g.fchk')).to_universe()

fni.add_molecular_orbitals(vector=range(10))

UW(fni)
```