### PR TITLE
Fixing build issues with version lock

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -3,7 +3,7 @@ name: Branch
 on:
   push:
     branches-ignore:
-      - [master, main]
+      [master, main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -48,6 +48,10 @@ jobs:
         with:
           path: ${{ env.pythonLocation }}
           key: ${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('requirements.txt') }}-${{ hashFiles('requirements.dev.txt') }}
+      - name: Use Node.js version 16
+        uses: actions/setup-node@v3
+        with:
+          node-version: "16.19.1"
       - name: Install Dependencies
         run: |
           pip install --upgrade --upgrade-strategy eager -r requirements.txt -r requirements.dev.txt -e .
@@ -71,3 +75,4 @@ jobs:
         with:
           project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
           coverage-reports: coverage.xml
+

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -39,6 +39,10 @@ jobs:
         with:
           path: ${{ env.pythonLocation }}
           key: ${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('requirements.txt') }}-${{ hashFiles('requirements.dev.txt') }}
+      - name: Use Node.js version 16
+        uses: actions/setup-node@v3
+        with:
+          node-version: "16.19.1"
       - name: Install Dependencies
         run: |
           pip install --upgrade --upgrade-strategy eager -r requirements.txt -r requirements.dev.txt -e .
@@ -70,8 +74,15 @@ jobs:
         run: |
           rm -rf docs/source/*.txt
           SPHINX_APIDOC_OPTIONS=members,undoc-members,show-inheritance sphinx-apidoc -eM -s txt -o docs/source/ exatomic *test*
-          travis-sphinx build
-          travis-sphinx deploy
+          sphinx-build docs/source _build
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+        with:
+          publish_branch: gh-pages
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: _build/
+          force_orphan: true
 
   # keep github release and pypi upload together
   publish-release:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,4 +1,4 @@
-name: Branch
+name: Pull Request
 
 on:
   pull_request:
@@ -46,6 +46,10 @@ jobs:
         with:
           path: ${{ env.pythonLocation }}
           key: ${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('requirements.txt') }}-${{ hashFiles('requirements.dev.txt') }}
+      - name: Use Node.js version 16
+        uses: actions/setup-node@v3
+        with:
+          node-version: "16.19.1"
       - name: Install Dependencies
         run: |
           pip install --upgrade --upgrade-strategy eager -r requirements.txt -r requirements.dev.txt -e .


### PR DESCRIPTION
Locked NPM version used in the workflow run to `16.19.1` as there was some issue starting with version `17.xx.xx`. Also, the publish step in the master workflow was fixed so the documentation is built and deployed to GitHub Pages correctly.

This will close #279 